### PR TITLE
Update .bat to support onedrive documents.

### DIFF
--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -1,35 +1,41 @@
 @echo off
 setlocal
 
+:: get Documents folder from registry ( will work even with onedrive )
+for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Personal') do set DOCUMENTS=%%b
+
+:: get Appdata folder from registry
+for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v AppData') do set APPDATA=%%b
+
 :: location to keep good local config files
-set "GOODCONFIGSDIR=%USERPROFILE%\Documents\game_configs"
+set "GOODCONFIGSDIR=%DOCUMENTS%\game_configs"
 
 :: create a directory to keep good config file
 mkdir "%GOODCONFIGSDIR%\%SteamAppId%"
 
 :: get location of config file used in game based on steam appid
 if %SteamAppId%==814380 (
-            set "GAMECONFIGDIR=Application Data\Sekiro"
+            set "GAMECONFIGDIR=%APPDATA%\Sekiro"
             set "GAMECONFIG=GraphicsConfig.xml"
 )
 if %SteamAppId%==292030 (
-            set "GAMECONFIGDIR=Documents\The Witcher 3"
+            set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
             set "GAMECONFIG=user.settings"
 )
 if %SteamAppId%==499450 (
-            set "GAMECONFIGDIR=Documents\The Witcher 3"
+            set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
             set "GAMECONFIG=user.settings"
 )
 if %SteamAppId%==32360 (
-            set "GAMECONFIGDIR=Application Data\LucasArts\The Secret of Monkey Island Special Edition"
+            set "GAMECONFIGDIR=%APPDATA%\LucasArts\The Secret of Monkey Island Special Edition"
             set "GAMECONFIG=Settings.ini"
 )
 if %SteamAppId%==1151640 (
-            set "GAMECONFIGDIR=Documents\Horizon Zero Dawn\Saved Game\profile"
+            set "GAMECONFIGDIR=%DOCUMENTS%\Horizon Zero Dawn\Saved Game\profile"
             set "GAMECONFIG=graphicsconfig.ini"
 )
 
-set "CONFIGPATH=%USERPROFILE%\%GAMECONFIGDIR%\%GAMECONFIG%"
+set "CONFIGPATH=%GAMECONFIGDIR%\%GAMECONFIG%"
 
 :: if this is defined then it's a game in the list so use the workaround
 if defined GAMECONFIG (goto workaround)


### PR DESCRIPTION
With this pr the documents and appdata folder are readed from the registry so you can use the workaround script even with onedrive documents.