### PR TITLE
Fix to witcher 3 new patch launcher ( only for windows )

### DIFF
--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal
+echo Cloud Config Workaround
 
 :: get Documents folder from registry ( will work even with onedrive )
 for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Personal') do set DOCUMENTS=%%b
@@ -17,26 +18,33 @@ set "GOODCONFIGSDIR=%DOCUMENTS%\game_configs"
 :: create a directory to keep good config file
 mkdir "%GOODCONFIGSDIR%\%SteamAppId%"
 
+set "GAMEEXE="""
+
 :: get location of config file used in game based on steam appid
 if %SteamAppId%==814380 (
             set "GAMECONFIGDIR=%APPDATA%\Sekiro"
             set "GAMECONFIG=GraphicsConfig.xml"
+            set "GAMEEXE="""
 )
 if %SteamAppId%==292030 (
             set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
             set "GAMECONFIG=user.settings"
+            set "GAMEEXE=witcher3.exe"
 )
 if %SteamAppId%==499450 (
             set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
             set "GAMECONFIG=user.settings"
+            set "GAMEEXE=witcher3.exe"
 )
 if %SteamAppId%==32360 (
             set "GAMECONFIGDIR=%APPDATA%\LucasArts\The Secret of Monkey Island Special Edition"
             set "GAMECONFIG=Settings.ini"
+            set "GAMEEXE="""
 )
 if %SteamAppId%==1151640 (
             set "GAMECONFIGDIR=%DOCUMENTS%\Horizon Zero Dawn\Saved Game\profile"
             set "GAMECONFIG=graphicsconfig.ini"
+            set "GAMEEXE="""
 )
 
 set "CONFIGPATH=%GAMECONFIGDIR%\%GAMECONFIG%"
@@ -47,11 +55,31 @@ if defined GAMECONFIG (goto workaround)
 %*
 exit
 
+:waitprocesstostart
+echo Waiting for %GAMEEXE% to start
+:: wait for game to start ( usefull if the game has a launcher )
+FOR /F %%x IN ('tasklist /NH /FI "IMAGENAME eq %GAMEEXE%"') DO IF %%x == %GAMEEXE% goto waitprocesstoend
+TIMEOUT /T 3
+goto waitprocesstostart
+
+:waitprocesstoend
+echo Waiting for %GAMEEXE% to end
+:: wait for game to end
+FOR /F %%x IN ('tasklist /NH /FI "IMAGENAME eq %GAMEEXE%"') DO IF %%x NEQ %GAMEEXE% goto saveconfig
+TIMEOUT /T 3
+goto waitprocesstoend
+
 :workaround
+echo Applying Workaround
 :: copy the wanted config file to the location used by game
 copy "%GOODCONFIGSDIR%\%SteamAppId%\%GAMECONFIG%" "%CONFIGPATH%"
 :: this is %command% (i.e. the game exe) and any parameters from the launch options
 %*
+IF %GAMEEXE% == "" (goto saveconfig)
+goto waitprocesstostart
+
+:saveconfig
+echo Saving Configs
 :: save any config changes you made in-game for next time
 copy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%\"
 exit


### PR DESCRIPTION
The new witcher 3 update add a launcher that broke the old script, I added a loop to wait for the game exe to start and a loop to wait for the game exe to end. I added a new variable GAMEEXE , if left empty the old script logic is used.