### PR TITLE
Move config paths to separate file for easier additions and maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cloud_config_workaround
+# cloud config workaround
 Workaround for games with graphics settings synced by Steam cloud
 
 Currently works for:
@@ -18,17 +18,39 @@ Currently works for:
 * DEATH STRANDING
 * Pinball M
 
-Please create a new issue for other games that also need a workaround
+## Game not on the list?
+Please create a new issue with the AppId and game name.
+Include the location and name of the file that holds the configuration. When looking for the file both https://steamdb.info/ and https://www.pcgamingwiki.com can be helpful.
 
-## To use:
+### How to add a game
+You can add another game by adding it to the paths.txt file.
+
+The format is:
+
+	AppID;directory/of/config;configfilename.ext
+	
+Example:
+
+	814380;%APPDATA%/Sekiro;GraphicsConfig.xml
+
+Add one game per line and use forward slashes as path separators with Windows style path variables where needed.
+
+If you successfully add another game please open a pull request so others can benefit.
+
+## How to use:
 
 ### Linux/Steam Deck
 
 Download the script somewhere and make sure it's set as executable.
+Also save the paths.txt file in the same place.
 
-Add the launch option to the relevant game
+Alternatively just use git:
 
-`/path/to/download/cloud_config_workaround.sh %command%`
+	git clone https://github.com/tmplshdw/cloud_config_workaround.git ~/cloud_config_workaround
+
+Add the launch option to the relevant game (change the location if you save it elsewhere)
+
+`/home/$USER/cloud_config_workaround.sh %command%`
 
 
 ### Windows

--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal
+set "SteamAppId=1687950"
 
 :: get Documents folder from registry ( will work even with onedrive )
 for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Personal') do set DOCUMENTS=%%b
@@ -20,69 +21,16 @@ mkdir "%GOODCONFIGSDIR%\%SteamAppId%"
 :: get SteamID3 version by converting 64 Bit SteamID with powershell
 for /f "delims=" %%a in ('powershell.exe -command "$result=%STEAMID%-76561197960265728; Write-Output $result"') do set SteamID3=%%a
 
-:: get location of config file used in game based on steam appid
-if %SteamAppId%==814380 (
-            set "GAMECONFIGDIR=%APPDATA%\Sekiro"
-            set "GAMECONFIG=GraphicsConfig.xml"
-)
-if %SteamAppId%==292030 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
-            set "GAMECONFIG=user.settings"
-)
-if %SteamAppId%==499450 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\The Witcher 3"
-            set "GAMECONFIG=user.settings"
-)
-if %SteamAppId%==32360 (
-            set "GAMECONFIGDIR=%APPDATA%\LucasArts\The Secret of Monkey Island Special Edition"
-            set "GAMECONFIG=Settings.ini"
-)
-if %SteamAppId%==1151640 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\Horizon Zero Dawn\Saved Game\profile"
-            set "GAMECONFIG=graphicsconfig.ini"
-)
-if %SteamAppId%==1313140 (
-            set "GAMECONFIGDIR=%USERPROFILE%\AppData\LocalLow\Massive Monster\Cult Of The Lamb\saves"
-            set "GAMECONFIG=settings.json"
-)
-if %SteamAppId%==524220 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\My Games\NieR_Automata"
-            set "GAMECONFIG=SystemData.dat"
-)
-if %SteamAppId%==1113560 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\My Games\NieR Replicant ver.1.22474487139\Steam\%STEAMID%"
-            set "GAMECONFIG=drawing_settings.ini"
-)
-if %SteamAppId%==757310 (
-            set "GAMECONFIGDIR=%USERPROFILE%\AppData\LocalLow\Shedworks\Sable\SaveData"
-            set "GAMECONFIG=SettingsManager"
-)
-if %SteamAppId%==1295510 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\My Games\DRAGON QUEST XI S\Steam\%SteamID3%\Saved\SaveGames\Book"
-            set "GAMECONFIG=system999.sav"
-)
-if %SteamAppId%==1687950 (
-            set "GAMECONFIGDIR=%APPDATA%\SEGA\P5R\Steam\%STEAMID%\savedata\SYSTEM"
-            set "GAMECONFIG=SYSTEM.DAT"
-)
-if %SteamAppId%==1730680 (
-            set "GAMECONFIGDIR=%LOCALAPPDATA%\Bandai Namco Entertainment/KLONOAencore\Saved\SaveGames\%SteamID3%"
-            set "GAMECONFIG=System.bin"
-)
-if %SteamAppId%==990080 (
-            set "GAMECONFIGDIR=%USERPROFILE%\AppData\Local\Hogwarts Legacy\Saved\SaveGames\%SteamID3%"
-            set "GAMECONFIG=SavedUserOptions.sav"
-)
-if %SteamAppId%==1608070 (
-            set "GAMECONFIGDIR=%DOCUMENTS%\My Games\CRISIS CORE FINAL FANTASY VII REUNION\Steam\%STEAMID%"
-            set "GAMECONFIG=SAVEDATA_SYSTEM.sav"
-)
-if %SteamAppId%==2337640 (
-            set "GAMECONFIGDIR=%USERPROFILE%\AppData\Local\PinballM\Saved\SaveGames\%STEAMID%"
-            set "GAMECONFIG=settings.sav"
-)
+:: get location of config file from the paths.txt file based on steam appid
+for /f "tokens=2 delims=;" %%F in ('findstr %SteamAppId% paths.txt') do set "CONFIGPATH=%%F"
 
-set "CONFIGPATH=%GAMECONFIGDIR%\%GAMECONFIG%"
+:: get just the config file name
+for /f "delims=|" %%F in ("%CONFIGPATH%") do set "GAMECONFIG=%%~nxF"
+
+if defined CONFIGPATH (echo %CONFIGPATH%)
+if defined GAMECONFIG (echo %GAMECONFIG%)
+pause
+exit
 
 :: if this is defined then it's a game in the list so use the workaround
 if defined GAMECONFIG (goto workaround)

--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
-set "SteamAppId=1687950"
+
+set "scriptpath=%~dp0"
 
 :: get Documents folder from registry ( will work even with onedrive )
 for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Personal') do set DOCUMENTS=%%b
@@ -22,15 +23,12 @@ mkdir "%GOODCONFIGSDIR%\%SteamAppId%"
 for /f "delims=" %%a in ('powershell.exe -command "$result=%STEAMID%-76561197960265728; Write-Output $result"') do set SteamID3=%%a
 
 :: get location of config file from the paths.txt file based on steam appid
-for /f "tokens=2 delims=;" %%F in ('findstr %SteamAppId% paths.txt') do set "CONFIGPATH=%%F"
+for /f "tokens=2 delims=;" %%F in ('findstr %SteamAppId% %scriptpath%paths.txt') do set "CONFIGPATH=%%F"
+call set "CONFIGPATH=%CONFIGPATH%"
 
-:: get just the config file name
-for /f "delims=|" %%F in ("%CONFIGPATH%") do set "GAMECONFIG=%%~nxF"
-
-if defined CONFIGPATH (echo %CONFIGPATH%)
-if defined GAMECONFIG (echo %GAMECONFIG%)
-pause
-exit
+:: get the config file name
+for /f "tokens=3 delims=;" %%F in ('findstr %SteamAppId% %scriptpath%paths.txt') do set "GAMECONFIG=%%F"
+call set "GAMECONFIG=%GAMECONFIG%"
 
 :: if this is defined then it's a game in the list so use the workaround
 if defined GAMECONFIG (goto workaround)
@@ -40,9 +38,9 @@ exit
 
 :workaround
 :: copy the wanted config file to the location used by game
-copy "%GOODCONFIGSDIR%\%SteamAppId%\%GAMECONFIG%" "%CONFIGPATH%"
+robocopy "%GOODCONFIGSDIR%\%SteamAppId%" "%CONFIGPATH%" "%GAMECONFIG%" /V 
 :: this is %command% (i.e. the game exe) and any parameters from the launch options
 %*
 :: save any config changes you made in-game for next time
-copy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%\"
+robocopy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%" "%GAMECONFIG%" /V
 exit

--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -38,9 +38,10 @@ exit
 
 :workaround
 :: copy the wanted config file to the location used by game
-robocopy "%GOODCONFIGSDIR%\%SteamAppId%" "%CONFIGPATH%" "%GAMECONFIG%" /V 
+robocopy "%GOODCONFIGSDIR%\%SteamAppId%" "%CONFIGPATH%" "%GAMECONFIG%" /LOG:%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log
 :: this is %command% (i.e. the game exe) and any parameters from the launch options
 %*
 :: save any config changes you made in-game for next time
-robocopy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%" "%GAMECONFIG%" /V
+robocopy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%" "%GAMECONFIG%" /LOG+:%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log
+
 exit

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -15,73 +15,14 @@ STEAMID=$(grep -Pzo '"'${SteamUser}'"\s+{\s+"SteamID"\s+"[0-9]+"' /home/${USER}/
 # get SteamID3 version by converting 64 Bit SteamID
 SteamID3=$((${STEAMID}-76561197960265728))
 
-# get location of config file used in game based on steam appid
-case ${SteamAppId} in
-    814380)
-        CONFIG_PATH="Application Data/Sekiro"
-        CONFIG="GraphicsConfig.xml"
-        ;;
-    292030 | 499450) # 499450 GOTY edition, not sure if necessary
-        CONFIG_PATH="Documents/The Witcher 3"
-        CONFIG="user.settings"
-        ;;
-    32360)
-        CONFIG_PATH="Application Data/LucasArts/The Secret of Monkey Island Special Edition"
-        CONFIG="Settings.ini"
-        ;;
-    1151640)
-        CONFIG_PATH="Documents/Horizon Zero Dawn/Saved Game/profile"
-        CONFIG="graphicsconfig.ini"
-        ;;
-    1313140)
-        CONFIG_PATH="AppData/LocalLow/Massive Monster/Cult Of The Lamb/saves"
-        CONFIG="settings.json"
-        ;;
-    524220)
-        CONFIG_PATH="Documents/My Games/NieR_Automata"
-        CONFIG="SystemData.dat"
-        ;;
-    1113560)
-        CONFIG_PATH="Documents/My Games/NieR Replicant ver.1.22474487139/Steam/${STEAMID}"
-        CONFIG="drawing_settings.ini"
-        ;;
-    757310)
-        CONFIG_PATH="AppData/LocalLow/Shedworks/Sable/SaveData"
-        CONFIG="SettingsManager"
-        ;;
-    1295510)
-        CONFIG_PATH="Documents/My Games/DRAGON QUEST XI S/Steam/${SteamID3}/Saved/SaveGames/Book"
-        CONFIG="system999.sav"
-        ;;
-    1687950)
-        CONFIG_PATH="Application Data/SEGA/P5R/Steam/${STEAMID}/savedata/SYSTEM"
-        CONFIG="SYSTEM.DAT"
-        ;;
-    1730680)
-        CONFIG_PATH="AppData/Local/Bandai Namco Entertainment/KLONOAencore/Saved/SaveGames/${SteamID3}"
-        CONFIG="System.bin"
-        ;;
-    990080)
-        CONFIG_PATH="AppData/Local/Hogwarts Legacy/Saved/SaveGames/${SteamID3}"
-        CONFIG="SavedUserOptions.sav"
-        ;;
-    1608070)
-        CONFIG_PATH="Documents/My Games/CRISIS CORE FINAL FANTASY VII REUNION/Steam/${STEAMID}"
-        CONFIG="SAVEDATA_SYSTEM.sav"
-        ;;
-    2337640)
-        CONFIG_PATH="AppData/Local/PinballM/Saved/SaveGames/${STEAMID}"
-        CONFIG="settings.sav"
-        ;;
-    *)
-        CONFIG="error"
-        ;;
-esac
+# get the path of config from the paths.txt file
+CONFIG_PATH=$(grep ${SteamAppId} "$(dirname $0)/paths.txt" | cut --delimiter=';' --fields=2 -)
+CONFIG=${CONFIG_PATH##*/} #https://stackoverflow.com/a/23497364
 
 # STEAM_COMPAT_DATA_PATH is set by Steam to be the location for the prefix used by the game
 # by default ~/.local/share/Steam/steamapps/compatdata/$SteamAppId
 # but may be elsewhere depending on how you set up your steam library storage
-GAME_CONFIG_PATH="${STEAM_COMPAT_DATA_PATH}/${WIN_USER_PATH}/${CONFIG_PATH}/${CONFIG}"
+GAME_CONFIG_PATH="${STEAM_COMPAT_DATA_PATH}/${WIN_USER_PATH}/${CONFIG_PATH}"
 echo "game config file: ${GAME_CONFIG_PATH}" >> ${LOGFILE} 2>&1
 
 if [ "${CONFIG}" = "error" ]; then # run the game without workaround

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -2,6 +2,8 @@
 
 # location to keep good local config files
 GOOD_CONFIGS_PATH="/home/${USER}/Documents/game_configs"
+# location of paths.txt file containing the config paths for games, default in script directory
+PATHS_FILE="$(dirname $0)/paths.txt"
 LOGFILE="${GOOD_CONFIGS_PATH}/${SteamAppId}_config_workaround.log"
 # user directory in the proton prefix
 WIN_USER_PATH="pfx/drive_c/users/steamuser"
@@ -16,16 +18,25 @@ STEAMID=$(grep -Pzo '"'${SteamUser}'"\s+{\s+"SteamID"\s+"[0-9]+"' /home/${USER}/
 SteamID3=$((${STEAMID}-76561197960265728))
 
 # get the path of config from the paths.txt file
-CONFIG_PATH=$(grep ${SteamAppId} "$(dirname $0)/paths.txt" | cut --delimiter=';' --fields=2 -)
-CONFIG=${CONFIG_PATH##*/} #https://stackoverflow.com/a/23497364
+CONFIG_PATH=$(grep ${SteamAppId} ${PATHS_FILE} | cut --delimiter=';' --fields=2 -)
+CONFIG=$(grep ${SteamAppId} ${PATHS_FILE} | cut --delimiter=';' --fields=3 -)
+
+# replace Windows path variables with their equivalent for Proton prefix
+CONFIG_PATH=$(echo ${CONFIG_PATH} | sed \
+    -e 's/%APPDATA%/Application Data/'\
+    -e 's/%DOCUMENTS%/Documents/'\
+    -e 's/%USERPROFILE%//'\
+    -e 's/%LOCALAPPDATA%/AppData\/Local/'\
+    -e 's/%STEAMID%/\${STEAMID}/'\
+    -e 's/%SteamID3%/\${SteamID3}/'\
+)
 
 # STEAM_COMPAT_DATA_PATH is set by Steam to be the location for the prefix used by the game
 # by default ~/.local/share/Steam/steamapps/compatdata/$SteamAppId
 # but may be elsewhere depending on how you set up your steam library storage
 GAME_CONFIG_PATH="${STEAM_COMPAT_DATA_PATH}/${WIN_USER_PATH}/${CONFIG_PATH}"
-echo "game config file: ${GAME_CONFIG_PATH}" >> ${LOGFILE} 2>&1
 
-if [ "${CONFIG}" = "error" ]; then # run the game without workaround
+if [ -z ${CONFIG} ]; then # run the game without workaround
     echo "error" >> ${LOGFILE} 2>&1
     "$@" # filled in with %command% (game executable stuff) and any other launch options
 else
@@ -35,5 +46,5 @@ else
     "$@" # filled in with %command% (game executable stuff) and any other launch options
 
     # save any config changes you made in-game for next time
-    cp -v "${GAME_CONFIG_PATH}" "${GOOD_CONFIGS_PATH}/${SteamAppId}/" >> "${LOGFILE}" 2>&1
+    cp -v "${GAME_CONFIG_PATH}/${CONFIG}" "${GOOD_CONFIGS_PATH}/${SteamAppId}/" >> "${LOGFILE}" 2>&1
 fi

--- a/paths.txt
+++ b/paths.txt
@@ -13,6 +13,6 @@
 990080;%USERPROFILE%/AppData/Local/Hogwarts Legacy/Saved/SaveGames/%SteamID3%;SavedUserOptions.sav
 1608070;%DOCUMENTS%/My Games/CRISIS CORE FINAL FANTASY VII REUNION/Steam/%STEAMID%;SAVEDATA_SYSTEM.sav
 2337640;%USERPROFILE%/AppData/Local/PinballM/Saved/SaveGames/%STEAMID%;settings.sav
-1850570;%LOCALAPPDATA%/KojimaProductions/DeathStrandingDC/%SteamID3%/profile;game_settings.cfg"
-1190460;%LOCALAPPDATA%/KojimaProductions/DeathStranding/%SteamID3%/profile;game_settings.cfg"
+1850570;%LOCALAPPDATA%/KojimaProductions/DeathStrandingDC/%SteamID3%/profile;game_settings.cfg
+1190460;%LOCALAPPDATA%/KojimaProductions/DeathStranding/%SteamID3%/profile;game_settings.cfg
 

--- a/paths.txt
+++ b/paths.txt
@@ -1,16 +1,18 @@
-814380;Application Data/Sekiro/GraphicsConfig.xml
-292030;Documents/The Witcher 3/user.settings
-499450;Documents/The Witcher 3/user.settings
-32360;Application Data/LucasArts/The Secret of Monkey Island Special Edition/Settings.ini
-1151640;Documents/Horizon Zero Dawn/Saved Game/profile/graphicsconfig.ini
-1313140;AppData/LocalLow/Massive Monster/Cult Of The Lamb/saves/settings.json
-524220;Documents/My Games/NieR_Automata/SystemData.dat
-1113560;Documents/My Games/NieR Replicant ver.1.22474487139/Steam/${STEAMID}/drawing_settings.ini
-757310;AppData/LocalLow/Shedworks/Sable/SaveData/SettingsManager
-1295510;Documents/My Games/DRAGON QUEST XI S/Steam/${SteamID3}/Saved/SaveGames/Book/system999.sav
-1687950;Application Data/SEGA/P5R/Steam/${STEAMID}/savedata/SYSTEM/SYSTEM.DAT
-1730680;AppData/Local/Bandai Namco Entertainment/KLONOAencore/Saved/SaveGames/${SteamID3}/System.bin
-990080;AppData/Local/Hogwarts Legacy/Saved/SaveGames/${SteamID3}/SavedUserOptions.sav
-1608070;Documents/My Games/CRISIS CORE FINAL FANTASY VII REUNION/Steam/${STEAMID}/SAVEDATA_SYSTEM.sav
-2337640;AppData/Local/PinballM/Saved/SaveGames/${STEAMID}/settings.sav
+814380;%APPDATA%/Sekiro;GraphicsConfig.xml
+292030;%DOCUMENTS%/The Witcher 3;user.settings
+499450;%DOCUMENTS%/The Witcher 3;user.settings
+32360;%APPDATA%/LucasArts/The Secret of Monkey Island Special Edition;Settings.ini
+1151640;%DOCUMENTS%/Horizon Zero Dawn/Saved Game/profile;graphicsconfig.ini
+1313140;%USERPROFILE%/AppData/LocalLow/Massive Monster/Cult Of The Lamb/saves;settings.json
+524220;%DOCUMENTS%/My Games/NieR_Automata;SystemData.dat
+1113560;%DOCUMENTS%/My Games/NieR Replicant ver.1.22474487139/Steam/%STEAMID%;drawing_settings.ini
+757310;%USERPROFILE%/AppData/LocalLow/Shedworks/Sable/SaveData;SettingsManager
+1295510;%DOCUMENTS%/My Games/DRAGON QUEST XI S/Steam/%SteamID3%/Saved/SaveGames/Book;system999.sav
+1687950;%APPDATA%/SEGA/P5R/Steam/%STEAMID%/savedata/SYSTEM;SYSTEM.DAT
+1730680;%LOCALAPPDATA%/Bandai Namco Entertainment/KLONOAencore/Saved/SaveGames/%SteamID3%;System.bin
+990080;%USERPROFILE%/AppData/Local/Hogwarts Legacy/Saved/SaveGames/%SteamID3%;SavedUserOptions.sav
+1608070;%DOCUMENTS%/My Games/CRISIS CORE FINAL FANTASY VII REUNION/Steam/%STEAMID%;SAVEDATA_SYSTEM.sav
+2337640;%USERPROFILE%/AppData/Local/PinballM/Saved/SaveGames/%STEAMID%;settings.sav
+1850570;%LOCALAPPDATA%/KojimaProductions/DeathStrandingDC/%SteamID3%/profile;game_settings.cfg"
+1190460;%LOCALAPPDATA%/KojimaProductions/DeathStranding/%SteamID3%/profile;game_settings.cfg"
 

--- a/paths.txt
+++ b/paths.txt
@@ -1,0 +1,16 @@
+814380;Application Data/Sekiro/GraphicsConfig.xml
+292030;Documents/The Witcher 3/user.settings
+499450;Documents/The Witcher 3/user.settings
+32360;Application Data/LucasArts/The Secret of Monkey Island Special Edition/Settings.ini
+1151640;Documents/Horizon Zero Dawn/Saved Game/profile/graphicsconfig.ini
+1313140;AppData/LocalLow/Massive Monster/Cult Of The Lamb/saves/settings.json
+524220;Documents/My Games/NieR_Automata/SystemData.dat
+1113560;Documents/My Games/NieR Replicant ver.1.22474487139/Steam/${STEAMID}/drawing_settings.ini
+757310;AppData/LocalLow/Shedworks/Sable/SaveData/SettingsManager
+1295510;Documents/My Games/DRAGON QUEST XI S/Steam/${SteamID3}/Saved/SaveGames/Book/system999.sav
+1687950;Application Data/SEGA/P5R/Steam/${STEAMID}/savedata/SYSTEM/SYSTEM.DAT
+1730680;AppData/Local/Bandai Namco Entertainment/KLONOAencore/Saved/SaveGames/${SteamID3}/System.bin
+990080;AppData/Local/Hogwarts Legacy/Saved/SaveGames/${SteamID3}/SavedUserOptions.sav
+1608070;Documents/My Games/CRISIS CORE FINAL FANTASY VII REUNION/Steam/${STEAMID}/SAVEDATA_SYSTEM.sav
+2337640;AppData/Local/PinballM/Saved/SaveGames/${STEAMID}/settings.sav
+


### PR DESCRIPTION
- paths are now in separate file, easier to add new ones
- copying in Windows now uses robocopy and has a log file
- use Windows path variables, swapped by .sh for their Proton counterparts