### PR TITLE
Adds support for KH3 Steam

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently works for:
 * CRISIS CORE –FINAL FANTASY VII– REUNION
 * DEATH STRANDING
 * Pinball M
+* KINGDOM HEARTS III + Re Mind (DLC)
 
 ## Game not on the list?
 Please create a new issue with the AppId and game name.

--- a/paths.txt
+++ b/paths.txt
@@ -15,4 +15,4 @@
 2337640;%USERPROFILE%/AppData/Local/PinballM/Saved/SaveGames/%STEAMID%;settings.sav
 1850570;%LOCALAPPDATA%/KojimaProductions/DeathStrandingDC/%SteamID3%/profile;game_settings.cfg
 1190460;%LOCALAPPDATA%/KojimaProductions/DeathStranding/%SteamID3%/profile;game_settings.cfg
-
+2552450;%DOCUMENTS%/My Games/KINGDOM HEARTS III/Steam/%STEAMID%/Config;GameUserSettings.ini


### PR DESCRIPTION
Since Steam cloud saving carries over the graphic settings too, unless it gets fixed with a future update this script does it's job just fine.