### PR TITLE
Follow symlinks to the real location of path.txt

### DIFF
--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -3,7 +3,8 @@
 # location to keep good local config files
 GOOD_CONFIGS_PATH="/home/${USER}/Documents/game_configs"
 # location of paths.txt file containing the config paths for games, default in script directory
-PATHS_FILE="$(dirname $0)/paths.txt"
+PATHS_FILE="$(dirname $(readlink -f $0))/paths.txt"
+
 LOGFILE="${GOOD_CONFIGS_PATH}/${SteamAppId}_config_workaround.log"
 # user directory in the proton prefix
 WIN_USER_PATH="pfx/drive_c/users/steamuser"

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -4,7 +4,6 @@
 GOOD_CONFIGS_PATH="/home/${USER}/Documents/game_configs"
 # location of paths.txt file containing the config paths for games, default in script directory
 PATHS_FILE="$(dirname $(readlink -f $0))/paths.txt"
-
 LOGFILE="${GOOD_CONFIGS_PATH}/${SteamAppId}_config_workaround.log"
 # user directory in the proton prefix
 WIN_USER_PATH="pfx/drive_c/users/steamuser"


### PR DESCRIPTION
This change ensures that the script can always find the correct location of `paths.txt`, even when the script is executed from a symlink.

Example:

Symlink in question:
```bash
lrwxrwxrwx 1 user users 57 Jul 21 13:38 cloud_config_workaround -> .tools/cloud_config_workaround/cloud_config_workaround.sh
```

**Before proposed change**, with symlink execution (incorrect PATHS_FILE value):
```bash
./cloud_config_workaround 
/home/user/bin/paths.txt
```

**After proposed change**, with symlink execution (correct PATHS_FILE value):
```bash
./cloud_config_workaround
/home/user/bin/.tools/cloud_config_workaround/paths.txt
```


