### PR TITLE
Add GGST Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently works for:
 * KINGDOM HEARTS III + Re Mind (DLC)
 * Disco Elysium - The Final Cut
 * SAND LAND
+* GUILTY GEAR -STRIVE-
 
 ## Game not on the list?
 Please create a new issue with the AppId and game name.

--- a/paths.txt
+++ b/paths.txt
@@ -21,4 +21,4 @@
 632470;%USERPROFILE%/AppData/LocalLow/ZAUM Studio/Disco Elysium/Settings;Settings.json
 2679460;%APPDATA%/SEGA/METAPHOR/%STEAMID%;pcconfig.dat
 1979440;%LOCALAPPDATA%/SANDLAND/Saved/SaveGames/%SteamID3%;System.sav
-1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;System.sav
+1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;SYSTEM.sav

--- a/paths.txt
+++ b/paths.txt
@@ -21,3 +21,4 @@
 632470;%USERPROFILE%/AppData/LocalLow/ZAUM Studio/Disco Elysium/Settings;Settings.json
 2679460;%APPDATA%/SEGA/METAPHOR/%STEAMID%;pcconfig.dat
 1979440;%LOCALAPPDATA%/SANDLAND/Saved/SaveGames/%SteamID3%;System.sav
+1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;System.sav


### PR DESCRIPTION
Adds GUILTY GEAR -STRIVE- support. Basically the same file as SAND LAND used.