### PR TITLE
MacOS Crossover Compatible bat script file

### DIFF
--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -18,6 +18,52 @@ for /f "tokens=*" %%a in (steam_appid.txt) do set "SteamAppId=%%a"
 :: Reparse the variable
 call set "SteamAppId=%SteamAppId%"
 
+@echo off
+setlocal enabledelayedexpansion
+
+if "%SteamAppId%"=="292030" (
+    set "GAMEEXE=witcher3.exe"
+    set "GAMEDIR=bin\x64_dx12"
+
+    if exist "launcher-configuration.json" (
+        set "FALLBACK_RAW="
+        for /f "tokens=2 delims=:" %%A in ('type "launcher-configuration.json" 2^>nul ^| find /i "fallback"') do (
+            set "FALLBACK_RAW=%%A"
+        )
+
+        if not "!FALLBACK_RAW!"=="" (
+            set "FALLBACK=!FALLBACK_RAW:,=!"
+            set "FALLBACK=!FALLBACK:"=!"
+            for /f "tokens=*" %%B in ("!FALLBACK!") do set "FALLBACK=%%B"
+            
+            if /i "!FALLBACK!"=="DirectX 11" set "GAMEDIR=bin\x64"
+            if /i "!FALLBACK!"=="DirectX 12" set "GAMEDIR=bin\x64_dx12"
+        )
+    )
+)
+
+if "%SteamAppId%"=="499450" (
+    set "GAMEEXE=witcher3.exe"
+    set "GAMEDIR=bin\x64_dx12"
+
+    if exist "launcher-configuration.json" (
+        set "FALLBACK_RAW="
+        for /f "tokens=2 delims=:" %%A in ('type "launcher-configuration.json" 2^>nul ^| find /i "fallback"') do (
+            set "FALLBACK_RAW=%%A"
+        )
+
+        if not "!FALLBACK_RAW!"=="" (
+            set "FALLBACK=!FALLBACK_RAW:,=!"
+            set "FALLBACK=!FALLBACK:"=!"
+            for /f "tokens=*" %%B in ("!FALLBACK!") do set "FALLBACK=%%B"
+            
+            if /i "!FALLBACK!"=="DirectX 11" set "GAMEDIR=bin\x64"
+            if /i "!FALLBACK!"=="DirectX 12" set "GAMEDIR=bin\x64_dx12"
+        )
+    )
+)
+
+
 :: location to keep good local config files
 set "GOODCONFIGSDIR=%DOCUMENTS%\game_configs"
 
@@ -35,15 +81,21 @@ call set "GAMECONFIG=%GAMECONFIG%"
 :: if this is defined then it's a game in the list so use the workaround
 if defined GAMECONFIG (goto workaround)
 :: else just run the game
-%*
-exit
+:: %*
+:: exit
 
 :workaround
 :: copy the wanted config file to the location used by game
 copy "%GOODCONFIGSDIR%\%SteamAppId%\%GAMECONFIG%" "%CONFIGPATH%" > "%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log"
-:: this is %command% (i.e. the game exe) and any parameters from the launch options
-%*
+
+:: Check if we defined a custom exe/dir (like for Witcher 3), otherwise run default
+if defined GAMEEXE (
+    start /wait "" /d "%GAMEDIR%" "%GAMEEXE%"
+) else (
+    %*
+)
+
 :: save any config changes you made in-game for next time
 copy "%CONFIGPATH%\%GAMECONFIG%" "%GOODCONFIGSDIR%\%SteamAppId%" >> "%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log"
 
-exit
+:: exit

--- a/cloud_config_workaround.bat
+++ b/cloud_config_workaround.bat
@@ -3,7 +3,7 @@ setlocal
 
 set "scriptpath=%~dp0"
 
-:: get Documents folder from registry ( will work even with onedrive )
+:: get Documents folder from registry (will work even with OneDrive)
 for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Personal') do set DOCUMENTS=%%b
 :: Reparse the variable
 call set "DOCUMENTS=%DOCUMENTS%"
@@ -13,14 +13,16 @@ for /f "tokens=2*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Wind
 :: Reparse the variable
 call set "APPDATA=%APPDATA%"
 
+:: get SteamAppId from steam_appid.txt
+for /f "tokens=*" %%a in (steam_appid.txt) do set "SteamAppId=%%a"
+:: Reparse the variable
+call set "SteamAppId=%SteamAppId%"
+
 :: location to keep good local config files
 set "GOODCONFIGSDIR=%DOCUMENTS%\game_configs"
 
 :: create a directory to keep good config file
 mkdir "%GOODCONFIGSDIR%\%SteamAppId%"
-
-:: get SteamID3 version by converting 64 Bit SteamID with powershell
-for /f "delims=" %%a in ('powershell.exe -command "$result=%STEAMID%-76561197960265728; Write-Output $result"') do set SteamID3=%%a
 
 :: get location of config file from the paths.txt file based on steam appid
 for /f "tokens=2 delims=;" %%F in ('findstr %SteamAppId% %scriptpath%paths.txt') do set "CONFIGPATH=%%F"
@@ -38,10 +40,10 @@ exit
 
 :workaround
 :: copy the wanted config file to the location used by game
-robocopy "%GOODCONFIGSDIR%\%SteamAppId%" "%CONFIGPATH%" "%GAMECONFIG%" /LOG:%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log
+copy "%GOODCONFIGSDIR%\%SteamAppId%\%GAMECONFIG%" "%CONFIGPATH%" > "%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log"
 :: this is %command% (i.e. the game exe) and any parameters from the launch options
 %*
 :: save any config changes you made in-game for next time
-robocopy "%CONFIGPATH%" "%GOODCONFIGSDIR%\%SteamAppId%" "%GAMECONFIG%" /LOG+:%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log
+copy "%CONFIGPATH%\%GAMECONFIG%" "%GOODCONFIGSDIR%\%SteamAppId%" >> "%GOODCONFIGSDIR%\%SteamAppId%_config_workaround.log"
 
 exit

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # location to keep good local config files
 GOOD_CONFIGS_PATH="/home/${USER}/Documents/game_configs"
@@ -31,19 +31,60 @@ CONFIG_PATH=$(echo ${CONFIG_PATH} | sed \
     -e "s/%SteamID3%/${SteamID3}/"\
 )
 
+if [ "$SteamAppId" = "292030" ] || [ "$SteamAppId" = "499450" ]; then
+    GAMEEXE="witcher3.exe"
+    GAMEDIR="bin\\x64_dx12"
+
+    if [ -f "launcher-configuration.json" ]; then
+        FALLBACK_RAW=$(grep -i '"fallback"' launcher-configuration.json 2>/dev/null | cut -d: -f2)
+
+        if [ -n "$FALLBACK_RAW" ]; then
+            FALLBACK=$(echo "$FALLBACK_RAW" | tr -d '",\r' | xargs)
+            FALLBACK_LOWER="${FALLBACK,,}"
+
+            if [ "$FALLBACK_LOWER" = "directx 11" ]; then
+                GAMEDIR="bin\\x64"
+            elif [ "$FALLBACK_LOWER" = "directx 12" ]; then
+                GAMEDIR="bin\\x64_dx12"
+            fi
+        fi
+    fi
+fi
+
 # STEAM_COMPAT_DATA_PATH is set by Steam to be the location for the prefix used by the game
 # by default ~/.local/share/Steam/steamapps/compatdata/$SteamAppId
 # but may be elsewhere depending on how you set up your steam library storage
 GAME_CONFIG_PATH="${STEAM_COMPAT_DATA_PATH}/${WIN_USER_PATH}/${CONFIG_PATH}"
 
-if [ -z ${CONFIG} ]; then # run the game without workaround
+if [ -z "${CONFIG}" ]; then # run the game without workaround
     echo "error" >> ${LOGFILE} 2>&1
     "$@" # filled in with %command% (game executable stuff) and any other launch options
 else
     # copy the wanted config file to the location used by game
     cp -v "${GOOD_CONFIGS_PATH}/${SteamAppId}/${CONFIG}" "${GAME_CONFIG_PATH}" >> "${LOGFILE}" 2>&1
 
-    "$@" # filled in with %command% (game executable stuff) and any other launch options
+    # Check if we defined a custom exe
+if [ -n "$GAMEEXE" ]; then
+    # 1. Convert any Windows backslashes in GAMEDIR to Linux forward slashes
+    GAMEDIR="${GAMEDIR//\\//}"
+
+    # 2. Rebuild the Steam launch command
+    NEW_CMD=()
+    for arg in "$@"; do
+        # If the argument ends in .exe, replace it with our custom path
+        if [[ "${arg,,}" == *".exe" ]]; then
+            NEW_CMD+=("$PWD/$GAMEDIR/$GAMEEXE")
+        else
+            NEW_CMD+=("$arg")
+        fi
+    done
+
+    # 3. Execute the modified Proton command
+    "${NEW_CMD[@]}"
+else
+    # Run the default command if no custom exe is set
+    "$@"
+fi
 
     # save any config changes you made in-game for next time
     cp -v "${GAME_CONFIG_PATH}/${CONFIG}" "${GOOD_CONFIGS_PATH}/${SteamAppId}/" >> "${LOGFILE}" 2>&1


### PR DESCRIPTION
On MacOS it is possible to run Windows versions of games through Crossover (Wine).

Unlike Linux, Steam is also running through Crossover so it needs .bat script files in the launch arguments.

I tried your script and there were two problems running it through Crossover : 

- The SteamAppId environment variable is never set by Steam so we need to get this from the steam_appid.txt file inside the game directory.
- robocopy doesn't work so we need to replace it by copy

So here is the updated .bat file compatible with both Windows and MacOS through Crossover.

I don't have a windows computer to test this new file at the moment so if you can please test it. I don't see why it wouldn't work but bugs are vicious :)