### PR TITLE
Fix: Refactor SteamID retrieval for RT3 and fix CONFIG_PATH generation

### DIFF
--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -29,6 +29,7 @@ CONFIG_PATH=$(echo ${CONFIG_PATH} | sed \
     -e "s/%LOCALAPPDATA%/AppData\/Local/"\
     -e "s/%STEAMID%/${STEAMID}/"\
     -e "s/%SteamID3%/${SteamID3}/"\
+    -e "s/^\///" \
 )
 
 # STEAM_COMPAT_DATA_PATH is set by Steam to be the location for the prefix used by the game

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -12,7 +12,7 @@ WIN_USER_PATH="pfx/drive_c/users/steamuser"
 mkdir -p "${GOOD_CONFIGS_PATH}/${SteamAppId}"
 
 # get most recently used account's 64 bit Steam ID
-STEAMID=$(grep -Pzo '"765611\d+"\s*\{\s*[^}]*?"MostRecent"\s*"1"' /home/${USER}/.local/share/Steam/config/loginusers.vdf | grep -a -oP '765611\d+')
+STEAMID=$(grep -Pzoi '"765611\d+"\s*\{\s*[^}]*?"MostRecent"\s*"1"' /home/${USER}/.local/share/Steam/config/loginusers.vdf | grep -a -oP '765611\d+')
 
 # get SteamID3 version by converting 64 Bit SteamID
 SteamID3=$((${STEAMID}-76561197960265728))

--- a/cloud_config_workaround.sh
+++ b/cloud_config_workaround.sh
@@ -11,8 +11,8 @@ WIN_USER_PATH="pfx/drive_c/users/steamuser"
 # create a directory to keep good config file
 mkdir -p "${GOOD_CONFIGS_PATH}/${SteamAppId}"
 
-# horrible kludge to get steamid
-STEAMID=$(grep -Pzo '"'${SteamUser}'"\s+{\s+"SteamID"\s+"[0-9]+"' /home/${USER}/.local/share/Steam/config/config.vdf | grep --text -oP '(?<=\s")[0-9]+')
+# get most recently used account's 64 bit Steam ID
+STEAMID=$(grep -Pzo '"765611\d+"\s*\{\s*[^}]*?"MostRecent"\s*"1"' /home/${USER}/.local/share/Steam/config/loginusers.vdf | grep -a -oP '765611\d+')
 
 # get SteamID3 version by converting 64 Bit SteamID
 SteamID3=$((${STEAMID}-76561197960265728))


### PR DESCRIPTION
Refactored the script to retrieve the active account's 64-bit SteamID directly from loginusers.vdf instead of relying on the ${SteamUser} environment variable, resolving an issue where the SteamRT3 client container strips the required environment variables on launch.

Also sanitized CONFIG_PATH generation to eliminate a redundant leading slash causing double-slash concatenation paths inside the Proton prefix.