### PR TITLE
Add support for Final Fantasy X & X-2 HD Remaster

### DIFF
--- a/paths.txt
+++ b/paths.txt
@@ -23,3 +23,5 @@
 1979440;%LOCALAPPDATA%/SANDLAND/Saved/SaveGames/%SteamID3%;System.sav
 1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;SYSTEM.sav
 1903340;%LOCALAPPDATA%/Sandfall/Saved/SaveGames/%STEAMID%;SharedGameUserSettings.sav
+359870;%DOCUMENTS%/SQUARE ENIX/FINAL FANTASY X&X-2 HD Remaster;GameSetting.ini
+


### PR DESCRIPTION
I have added support for  Final Fantasy X & X-2 HD Remaster, as graphics settings and bindings are stored in a separate ini file from the game saves.