### PR TITLE
Add support for Final Fantasy X & X-2 HD Remaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently works for:
 * SAND LAND
 * GUILTY GEAR -STRIVE-
 * Clair Obscur: Expedition 33
-*  Final Fantasy X & X-2 HD Remaster
+* Final Fantasy X & X-2 HD Remaster
 
 ## Game not on the list?
 Please create a new issue with the AppId and game name.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently works for:
 * SAND LAND
 * GUILTY GEAR -STRIVE-
 * Clair Obscur: Expedition 33
+*  Final Fantasy X & X-2 HD Remaster
 
 ## Game not on the list?
 Please create a new issue with the AppId and game name.

--- a/paths.txt
+++ b/paths.txt
@@ -23,3 +23,5 @@
 1979440;%LOCALAPPDATA%/SANDLAND/Saved/SaveGames/%SteamID3%;System.sav
 1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;SYSTEM.sav
 1903340;%LOCALAPPDATA%/Sandfall/Saved/SaveGames/%STEAMID%;SharedGameUserSettings.sav
+359870;%DOCUMENTS%/SQUARE ENIX/FINAL FANTASY X&X-2 HD Remaster;GameSetting.ini
+

--- a/paths.txt
+++ b/paths.txt
@@ -24,4 +24,3 @@
 1384160;%LOCALAPPDATA%/GGST/Saved/SaveGames/%SteamID3%;SYSTEM.sav
 1903340;%LOCALAPPDATA%/Sandfall/Saved/SaveGames/%STEAMID%;SharedGameUserSettings.sav
 359870;%DOCUMENTS%/SQUARE ENIX/FINAL FANTASY X&X-2 HD Remaster;GameSetting.ini
-


### PR DESCRIPTION
Add support for Final Fantasy X & X-2 HD Remaster, video options and bindings are stored in a separate ini file to game saves.