### PR TITLE
Document Controlled Folder Access troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Add the launch option to the relevant game
 
 `\path\to\download\cloud_config_workaround.bat %command%`
 
+#### Controlled folder access
+
+The Windows script stores configs and logs in the `game_configs` directory under your Windows Documents folder, including a redirected OneDrive Documents folder. If Windows Security reports that an unauthorized change was blocked, Controlled folder access may be preventing the script from writing there.
+
+Instead of disabling Controlled folder access, either change `GOODCONFIGSDIR` in `cloud_config_workaround.bat` to a location that is not listed under Protected folders (for example, `%LOCALAPPDATA%\game_configs` on a default Windows setup), or follow [Microsoft's instructions](https://support.microsoft.com/windows/virus-and-threat-protection-in-the-windows-security-app-1362f4cd-d71a-b52a-0b66-c2820032b65e) to review recently blocked apps and allow only an executable you trust.
+
 
 ### If using Flatpak version of Steam:
 Follow Linux/Steam Deck step and ensure you give the Steam Flatpak read/write access to your Documents folder. You may also need to provide read permissions for where you saved the cloud_config_workaround.sh script if you saved it outside your Documents folder. 


### PR DESCRIPTION
## Summary

- explain that Controlled Folder Access can block the Windows script from writing configs and logs under Documents
- document an alternative `GOODCONFIGSDIR` under `%LOCALAPPDATA%`
- link to Microsoft's steps for reviewing blocked apps instead of disabling the protection

## Why

The Windows script stores its working copies and logs in the user's Documents folder. When Controlled Folder Access protects that folder, users can see blocked-change notifications without an explanation in the setup instructions.

## Verification

- confirmed the documented location against `cloud_config_workaround.bat`, including redirected OneDrive Documents folders
- verified the Microsoft support link resolves successfully
- `git diff --check`

No script behavior or game configuration changed.

Closes #26
